### PR TITLE
fix uniform curve endpoint

### DIFF
--- a/src/powerstation.cpp
+++ b/src/powerstation.cpp
@@ -67,6 +67,11 @@ void Powerstation::ValidatePowerstationSettings() {
 ////////////////////////////////////////////////////////////////
 double Powerstation::calcEfficiency(size_t gen_idx, double q_m3s) {  // Calculate the efficiency for a specific generator and discharge.
 
+    if (gen_idx >= generators.size()) {
+        LOG_ERR("ERROR: Generator index out of bounds in powerstation " + std::to_string(int(idnr)) + " (" + nodename + ")");
+        return 0.0;
+    }
+
     if(q_m3s < 0.0) {
         LOG_WARN("ERROR: Discharge is negative for generator " + std::to_string(gen_idx) + " in powerstation " + std::to_string(int(idnr)) + " (" + nodename + "): Q = " + std::to_string(q_m3s));
         LOG_ERR("Check your action file, and make sure the discharge for generator " + std::to_string(gen_idx) + " in powerstation " + std::to_string(int(idnr)) + " (" + nodename + ") is not negative");
@@ -77,27 +82,31 @@ double Powerstation::calcEfficiency(size_t gen_idx, double q_m3s) {  // Calculat
         LOG_ERR("Check your action file, and make sure the discharge for generator " + std::to_string(gen_idx) + " in powerstation " + std::to_string(int(idnr)) + " (" + nodename + ") is not above the maximum discharge of the generator");
     }
 
-    if(gen_idx < 0) {
-        LOG_ERR("ERROR: Generator index is negative in powerstation " + std::to_string(int(idnr)) + " (" + nodename + "): gen_idx = " + std::to_string(gen_idx));
-    }
-
     if(q_m3s < 0.000001) {
         return 0.0;
     }
 
     if(generators[gen_idx].use_uniform_normalized_curve) {
+        if(generators[gen_idx].max_discharge <= 0.0) {
+            LOG_ERR("ERROR: Max discharge must be positive for uniform normalized curve in powerstation " + std::to_string(int(idnr)) + " (" + nodename + ")");
+            return 0.0;
+        }
+
         // We use the fast lookup method for uniform curves. 
         double Qn = q_m3s / generators[gen_idx].max_discharge;    // normalize to 0-1
-        int i = (int)(Qn * (N_UNIFORM_EFF_CURVE_POINTS-1));  // direct index calculation
-        double t = Qn * (N_UNIFORM_EFF_CURVE_POINTS-1) - i;  // fractional part for interpolation
+        if(Qn <= 0.0) {
+            return generators[gen_idx].uniform_normalized_curve[0] / 100.0;
+        }
+        if(Qn >= 1.0) {
+            return generators[gen_idx].uniform_normalized_curve[N_UNIFORM_EFF_CURVE_POINTS-1] / 100.0;
+        }
+
+        double scaled = Qn * (N_UNIFORM_EFF_CURVE_POINTS-1);
+        size_t i = static_cast<size_t>(scaled);  // direct index calculation
+        double t = scaled - i;  // fractional part for interpolation
         double eta = generators[gen_idx].uniform_normalized_curve[i] + t * (generators[gen_idx].uniform_normalized_curve[i+1] - generators[gen_idx].uniform_normalized_curve[i]);
         // cout << "Uniform normalized curve: gen_idx = " << gen_idx << ", Q = " << q_m3s << ", Qn = " << Qn << ", i = " << i << ", t = " << t << ", eta = " << eta << "\n";
         return eta / 100.0;
-    }
-
-    if (gen_idx >= generators.size()) {
-        LOG_ERR("ERROR: Generator index out of bounds in powerstation " + std::to_string(int(idnr)) + " (" + nodename + ")");
-        return 0.0;
     }
 
     // Default is to use old code with array curves. 

--- a/src_tests/test_powerstation.cpp
+++ b/src_tests/test_powerstation.cpp
@@ -449,6 +449,22 @@ TEST_F(PowerstationTest, Svoletjonn_OptimalEfficiency_MaxPowerPerFlow)
     EXPECT_GT(powerstation->S->Power[0], 0.6); // Should be efficient power production
 }
 
+TEST(PowerstationEfficiencyTest, UniformNormalizedCurve_MaxDischargeUsesLastPoint)
+{
+    Powerstation powerstation;
+    powerstation.idnr = 1;
+    powerstation.nodename = "TEST";
+    powerstation.generators.resize(1);
+    powerstation.generators[0].max_discharge = 4.0;
+    powerstation.generators[0].use_uniform_normalized_curve = true;
+    for (size_t i = 0; i < N_UNIFORM_EFF_CURVE_POINTS; ++i) {
+        powerstation.generators[0].uniform_normalized_curve[i] = 10.0 * i;
+    }
+
+    EXPECT_NEAR(powerstation.calcEfficiency(0, 2.0), 0.50, 1e-12);
+    EXPECT_NEAR(powerstation.calcEfficiency(0, 4.0), 1.00, 1e-12);
+}
+
 // Head Loss and Hydraulic Tests
 TEST_F(PowerstationTest, Simulate_SharedPenstock_CombinedHeadloss)
 {


### PR DESCRIPTION
This fixes the `UNIFORM_NORMALIZED_CURVE` efficiency lookup at exactly full generator discharge.

For an 11-point normalized curve, valid indices are `0..10`. At `q_m3s == max_discharge`, the current code computes:

```cpp
Qn = q_m3s / max_discharge = 1.0
i  = int(Qn * (N_UNIFORM_EFF_CURVE_POINTS - 1)) = 10
t  = Qn * (N_UNIFORM_EFF_CURVE_POINTS - 1) - i = 0.0
```

It then evaluates:

```cpp
uniform_normalized_curve[i]
    + t * (uniform_normalized_curve[i + 1] - uniform_normalized_curve[i])
```

With `i == 10`, this reads `uniform_normalized_curve[11]`, one past the end of the 11-element array. The interpolation fraction is zero, but the expression still references the `i + 1` element.

I verified this can fault, not only return a wrong value, with a small protected-page repro of the old expression. The repro places the 11-element curve at the end of a readable page and marks the following page inaccessible:

```text
old lookup: qn=1 i=10 t=0 reads indices 10 and 11
caught SIGSEGV: old formula read uniform_normalized_curve[11]
```

The fix handles the normalized endpoints explicitly and only interpolates for interior values:

- `Qn <= 0.0` returns the first point
- `Qn >= 1.0` returns the last point
- `0.0 < Qn < 1.0` uses the existing linear interpolation

I also moved the generator index bounds check before the first `generators[gen_idx]` access. The previous `gen_idx < 0` check is bad: `gen_idx` is `size_t` which cannot be negative. Accidental negative signed values passed to this function would underflow to large unsigned values and are now covered by `gen_idx >= generators.size()`.

## Validation

- Added `PowerstationEfficiencyTest.UniformNormalizedCurve_MaxDischargeUsesLastPoint`
- `make -C src herss.exe` passes locally
- Targeted GoogleTest run passes locally:

```bash
./test_powerstation_runner \
  --gtest_filter=PowerstationEfficiencyTest.UniformNormalizedCurve_MaxDischargeUsesLastPoint
```

- uTAHPS output comparison against `origin/main` is byte-identical for the checked uniform-curve sample cases:

```text
data/utahps_daily_new_format: identical
data/mini_utahps_spillway: identical
```

- Full `make -C src test` is not currently usable in my local checkout. After installing Fedora's `gtest-devel`, it fails while compiling pre-existing channel tests that reference `Channel::traveltime`, before reaching this regression test.


## Thoughts on Performance

This patch keeps the uniform curve lookup O(1). The added endpoint checks are simple scalar comparisons that avoid forming `i + 1` when `Qn` is exactly at either boundary. Interior points still use the same direct index calculation and linear interpolation as before.

`calcEfficiency()` can be called often during long simulations, but these checks are not expected to be measurable compared with the surrounding simulation work. I avoided compiler-specific branch hints here (such as C++20 `[[likely]]`) to keep the fix compatible.